### PR TITLE
add 45acp

### DIFF
--- a/src/Contents/mods/coavinsfirearms/media/lua/client/coavinsfirearms/CoavinsModels.lua
+++ b/src/Contents/mods/coavinsfirearms/media/lua/client/coavinsfirearms/CoavinsModels.lua
@@ -36,4 +36,7 @@ CoavinsFirearms.AddOrReplaceModel(
 , { 'AK47_Receiver', 'AK47_BoltCarrier' }
 , 'AK47_Receiver')
 
-CoavinsFirearms.AddOrReplaceModel('Pistol_45acp', { 'PistolReceiver_45acp ', 'PistolSlide_45acp'}, 'PistolReceiver_45acp')
+CoavinsFirearms.AddOrReplaceModel(
+  'Pistol_45acp'
+, { 'PistolReceiver_45acp ', 'PistolSlide_45acp'}
+, 'PistolReceiver_45acp')

--- a/src/Contents/mods/coavinsfirearms/media/lua/client/coavinsfirearms/CoavinsModels.lua
+++ b/src/Contents/mods/coavinsfirearms/media/lua/client/coavinsfirearms/CoavinsModels.lua
@@ -38,5 +38,5 @@ CoavinsFirearms.AddOrReplaceModel(
 
 CoavinsFirearms.AddOrReplaceModel(
   'Pistol_45acp'
-, { 'PistolReceiver_45acp ', 'PistolSlide_45acp'}
+, { 'PistolReceiver_45acp', 'PistolSlide_45acp'}
 , 'PistolReceiver_45acp')

--- a/src/Contents/mods/coavinsfirearms/media/lua/client/coavinsfirearms/CoavinsModels.lua
+++ b/src/Contents/mods/coavinsfirearms/media/lua/client/coavinsfirearms/CoavinsModels.lua
@@ -35,3 +35,5 @@ CoavinsFirearms.AddOrReplaceModel(
 	'AK47'
 , { 'AK47_Receiver', 'AK47_BoltCarrier' }
 , 'AK47_Receiver')
+
+CoavinsFirearms.AddOrReplaceModel('Pistol_45acp', { 'PistolReceiver_45acp ', 'PistolSlide_45acp'}, 'PistolReceiver_45acp')

--- a/src/Contents/mods/coavinsfirearms/media/lua/client/coavinsfirearms/FirearmsHelper.lua
+++ b/src/Contents/mods/coavinsfirearms/media/lua/client/coavinsfirearms/FirearmsHelper.lua
@@ -176,6 +176,19 @@ this.parts.AK47_Bolt = {}
 this.parts.AK47_Bolt.InsertsInto = 'AK47_BoltCarrier'
 this.parts.AK47_Bolt.ConditionLowerChance = 3
 this.parts.AK47_Bolt.ConditionMax = 20
+this.parts.PistolReceiver_45acp = {}
+this.parts.PistolReceiver_45acp.CombinesWith = 'PistolSlide_45acp'
+this.parts.PistolReceiver_45acp.ConditionLowerChance = 1 -- 100%
+this.parts.PistolReceiver_45acp.ConditionMax = 20
+this.parts.PistolSlide_45acp = {}
+this.parts.PistolSlide_45acp.CombinesWith = 'PistolReceiver_45acp'
+this.parts.PistolSlide_45acp.Holds = { 'PistolBarrel_45acp' }
+this.parts.PistolSlide_45acp.ConditionLowerChance = 2 -- 1/2
+this.parts.PistolSlide_45acp.ConditionMax = 20
+this.parts.PistolBarrel_45acp = {}
+this.parts.PistolBarrel_45acp.InsertsInto = 'PistolSlide_45acp'
+this.parts.PistolBarrel_45acp.ConditionLowerChance = 3 -- 1/3
+this.parts.PistolBarrel_45acp.ConditionMax = 20
 
 this.getPartModel = function(modelName)
 	return this.parts[modelName]

--- a/src/Contents/mods/coavinsfirearms/media/scripts/coavinsfirearms/fixings/coavins_fixing_pistol_45acp.txt
+++ b/src/Contents/mods/coavinsfirearms/media/scripts/coavinsfirearms/fixings/coavins_fixing_pistol_45acp.txt
@@ -1,0 +1,43 @@
+module coavinsfirearms {
+	imports {
+		Base
+	}
+
+	fixing Fix PistolReceiver Welding
+	{
+		Require : PistolReceiver,
+		GlobalItem : BlowTorch=2,
+	  ConditionModifier : 1.2,
+
+		Fixer : SmallSheetMetal; MetalWelding=3,
+		Fixer : ScrapMetal; MetalWelding=1,
+	}
+
+	fixing Fix PistolReceiver
+	{
+		Require : PistolReceiver,
+		ConditionModifier : 1,
+
+		Fixer : DuctTape=2; Aiming=4,
+		Fixer : Scotchtape=3; Aiming=2,
+	}
+
+	fixing Fix PistolSlide Welding
+	{
+		Require : PistolSlide,
+		GlobalItem : BlowTorch=2,
+	  ConditionModifier : 1.2,
+
+		Fixer : SmallSheetMetal; MetalWelding=3,
+		Fixer : ScrapMetal; MetalWelding=1,
+	}
+
+	fixing Fix PistolBarrel Welding
+	{
+		Require : PistolBarrel,
+		GlobalItem : BlowTorch=5,
+	  ConditionModifier : 1.2,
+
+		Fixer : SmallSheetMetal=2; MetalWelding=8,
+	}
+}

--- a/src/Contents/mods/coavinsfirearms/media/scripts/coavinsfirearms/fixings/coavins_fixing_pistol_45acp.txt
+++ b/src/Contents/mods/coavinsfirearms/media/scripts/coavinsfirearms/fixings/coavins_fixing_pistol_45acp.txt
@@ -3,9 +3,9 @@ module coavinsfirearms {
 		Base
 	}
 
-	fixing Fix PistolReceiver Welding
+	fixing Fix PistolReceiver_45acp Welding
 	{
-		Require : PistolReceiver,
+		Require : PistolReceiver_45acp,
 		GlobalItem : BlowTorch=2,
 	  ConditionModifier : 1.2,
 
@@ -13,18 +13,18 @@ module coavinsfirearms {
 		Fixer : ScrapMetal; MetalWelding=1,
 	}
 
-	fixing Fix PistolReceiver
+	fixing Fix PistolReceiver_45acp
 	{
-		Require : PistolReceiver,
+		Require : PistolReceiver_45acp,
 		ConditionModifier : 1,
 
 		Fixer : DuctTape=2; Aiming=4,
 		Fixer : Scotchtape=3; Aiming=2,
 	}
 
-	fixing Fix PistolSlide Welding
+	fixing Fix PistolSlide_45acp Welding
 	{
-		Require : PistolSlide,
+		Require : PistolSlide_45acp,
 		GlobalItem : BlowTorch=2,
 	  ConditionModifier : 1.2,
 
@@ -32,9 +32,9 @@ module coavinsfirearms {
 		Fixer : ScrapMetal; MetalWelding=1,
 	}
 
-	fixing Fix PistolBarrel Welding
+	fixing Fix PistolBarrel_45acp Welding
 	{
-		Require : PistolBarrel,
+		Require : PistolBarrel_45acp,
 		GlobalItem : BlowTorch=5,
 	  ConditionModifier : 1.2,
 

--- a/src/Contents/mods/coavinsfirearms/media/scripts/coavinsfirearms/weapons/coavins_parts_pistol_45acp.txt
+++ b/src/Contents/mods/coavinsfirearms/media/scripts/coavinsfirearms/weapons/coavins_parts_pistol_45acp.txt
@@ -1,0 +1,35 @@
+module coavinsfirearms {
+	imports {
+		Base
+	}
+
+	item PistolReceiver_45acp {
+		DisplayName = Pistol Frame (.45 ACP),
+		DisplayCategory = FirearmPart,
+		Type = Normal,
+		Icon = PistolReceiver,
+		Weight = 0.4,
+		ConditionMax = 20,
+		WorldStaticModel = Paperbag_Ground,
+	}
+
+	item PistolSlide_45acp {
+		DisplayName = Pistol Slide (.45 ACP),
+		DisplayCategory = FirearmPart,
+		Type = Normal,
+		Icon = PistolSlide,
+		Weight = 0.3,
+		ConditionMax = 20,
+		WorldStaticModel = Paperclip,
+	}
+
+	item PistolBarrel_45acp {
+		DisplayName = Pistol Barrel (.45 ACP),
+		DisplayCategory = FirearmPart,
+		Type = Normal,
+		Icon = PistolBarrel,
+		Weight = 0.3,
+		ConditionMax = 20,
+		WorldStaticModel = Razor_Ground,
+	}
+}

--- a/src/Contents/mods/coavinssupport2/media/lua/client/coavinssupport2/CoavinsInclude_WeaponPack.lua
+++ b/src/Contents/mods/coavinssupport2/media/lua/client/coavinssupport2/CoavinsInclude_WeaponPack.lua
@@ -265,7 +265,7 @@ CoavinsFirearms.Include('Base.CZ97B', 'GenericPistol')
 -- GLOCK.txt
 CoavinsFirearms.Include('Base.G17', 'GenericPistol')
 CoavinsFirearms.Include('Base.G18', 'GenericPistol')
-CoavinsFirearms.Include('Base.G21', 'GenericPistol')
+CoavinsFirearms.Include('Base.G21', 'Pistol_45acp')
 CoavinsFirearms.Include('Base.G34', 'GenericPistol')
 CoavinsFirearms.Include('Base.G42', 'GenericPistol')
 


### PR DESCRIPTION
- Add parts for .45 ACP pistol
- Add fixing recipe for .45 ACP pistol
- Add model for .45 ACP Pistol
- Add parts relationships for .45 ACP Pistol
- Change type for Glock 21 to Pistol_45acp
- Add Pistol_45acp
- Fix wrongly named item desc in fixings
- Fix extra space in model part name. This fixes Issue #45
